### PR TITLE
🚧  Fjern mappe og prioritet fra AutomatiskJournaløfringRequest

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/sak/journalføring/AutomatiskJournalføring.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/sak/journalføring/AutomatiskJournalføring.kt
@@ -1,15 +1,12 @@
 package no.nav.tilleggsstonader.kontrakter.sak.journalføring
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.kontrakter.oppgave.OppgavePrioritet
 import java.util.UUID
 
 data class AutomatiskJournalføringRequest(
     val personIdent: String,
     val journalpostId: String,
     val stønadstype: Stønadstype,
-    val mappeId: Long?,
-    val prioritet: OppgavePrioritet = OppgavePrioritet.NORM,
 )
 
 data class AutomatiskJournalføringResponse(

--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/sak/journalføring/AutomatiskJournalføring.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/sak/journalføring/AutomatiskJournalføring.kt
@@ -11,5 +11,5 @@ data class AutomatiskJournalføringRequest(
 
 data class AutomatiskJournalføringResponse(
     val fagsakId: UUID,
-    val behandlingId: UUID,
+    val behandlingId: UUID?,
 )


### PR DESCRIPTION
Oppfølging av https://github.com/navikt/tilleggsstonader-soknad-api/pull/39#discussion_r1374044565

`soknad-api` trenger ikke noe forhold til mappeId eller prioritet, da sak bør ha ansvar for dette.

Gjør også `behandlingId` i responsen nullable for når søknader ikke kan automatisk journalføres.