### PR TITLE
Oppdater data class for JournalposterForBrukerRequest

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/journalpost/JournalposterForBrukerRequest.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/journalpost/JournalposterForBrukerRequest.kt
@@ -4,7 +4,8 @@ import no.nav.tilleggsstonader.kontrakter.felles.Tema
 
 data class JournalposterForBrukerRequest(
     val brukerId: Bruker,
-    val antall: Int,
     val tema: List<Tema>? = null,
-    val journalposttype: List<Journalposttype>? = null,
+    val journalposttype: Journalposttype? = null,
+    val journalstatus: Journalstatus?,
+    val antall: Int = 200,
 )


### PR DESCRIPTION
### Hvorfor er dette nødvendig? 🤓 
For å hente dokumenter til dokumentoversikten har EF tatt i bruk to ulike request-dataklasser (`JournalposterForBrukerRequest` - gammel og `JournalposterForVedleggRequest` - tilhører ny dokumentoversikt) og to endepunkter i integrasjoner og sak. Ser ikke noe grunn til at vi trenger to, så bruker oppsettet til  `JournalposterForVedleggRequest`, men under navnet `JournalposterForBrukerRequest` fordi det er mer beskrivende. 

### Info som kan være nyttig
- `journalposttype` og `journalstatus` er ikke lister, dette gjør at man kan enten filtrere på "alle" eller "en" for disse feltene. Dette er sånn EF har bestemt at det skal fungere, og vi må gjøre en vurdering på om det er behov for å filtrere på flere ting samtidig (annet enn å vise alt). Foreløpig er dette va
- Hvis ikke `journalstatus` settes får man kun tilbake ferdigstilt, ekspedert eller journalført. Dette fikset EF [her](https://github.com/navikt/familie-integrasjoner/pull/890). Dette kan f.eks. håndteres i omgjøringen til en SafRequest (i integrasjoner) sånn her:

```kotlin
data class SafRequest(
    val brukerId: Bruker,
    val tema: List<Tema>?, // TODO: Arkivtema?
    val journalposttype: Journalposttype?,
    val journalstatus: List<Journalstatus>?,
    val antall: Int = 200,
)

fun JournalposterForBrukerRequest.tilSafRequestForBruker(): SafRequest {
    return SafRequestForBruker(
        brukerId = brukerId,
        tema = tema,
        journalposttype = journalposttype,
        journalstatus = journalstatus?.let { listOf(it) },
        antall = antall,
    )
}
```