### PR TITLE
Skal være mulig å filtrere på flere statuser og typer ved henting av …

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/journalpost/JournalposterForBrukerRequest.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/journalpost/JournalposterForBrukerRequest.kt
@@ -4,8 +4,8 @@ import no.nav.tilleggsstonader.kontrakter.felles.Tema
 
 data class JournalposterForBrukerRequest(
     val brukerId: Bruker,
-    val tema: List<Tema>? = null,
-    val journalposttype: Journalposttype? = null,
-    val journalstatus: Journalstatus?,
+    val tema: List<Tema> = emptyList(),
+    val journalposttype: List<Journalposttype> = emptyList(),
+    val journalstatus: List<Journalstatus> = emptyList(),
     val antall: Int = 200,
 )


### PR DESCRIPTION
…journalposter

I #31 var det ikke mulig å filtrere på flere statuser og typer. Etter prat med Johan gikk vi for å ha disse som lister og heller fjerne lister i kallet i sak, så kan klassen brukes på flere ting og heller mappes om i sak og integrasjoner. 