### PR TITLE
erSortert skal håndtere at to perioder muligvis er like

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/felles/Periode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/felles/Periode.kt
@@ -26,7 +26,7 @@ interface Periode<T> : Comparable<Periode<T>> where T : Comparable<T>, T : Tempo
 }
 
 fun <T> List<Periode<T>>.erSortert(): Boolean where T : Comparable<T>, T : Temporal {
-    return zipWithNext().all { it.first < it.second }
+    return zipWithNext().all { it.first <= it.second }
 }
 
 fun <T> List<Periode<T>>.overlapper(): Boolean where T : Comparable<T>, T : Temporal {


### PR DESCRIPTION
Fordi vilkårsperioder kan være overlappende bør Periode-objektet vårt også støtte det.

Gitt periodene `A, B og C`:
```
A = 01.01.2024-01.31.2024
B = 01.01.2024-01.31.2024
C =  01.02.2024-29.02.2024
```
Synes jeg det virker fornuftig at 

`listOf(A, B, C).erSortert()` returnerer `true`

Vi kan evt. legge til egen implementasjon av `erSortert` for `Stønadsperiode`, men ser i utgangspunktet ikke ut som at noen tester brekker av dette.

**Hvorfor gjør jeg dette?**
Jeg tenkte å bruke `erSortert()` ved validering av stønadsperioder/vilkårsperioder 🤓 