### PR TITLE
Kopiert dto for kodeverk som skal brukes av søknad-api og sak for å m…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/kodeverk/KodeverkDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/kodeverk/KodeverkDto.kt
@@ -1,0 +1,52 @@
+package no.nav.tilleggsstonader.kontrakter.kodeverk
+
+import java.time.LocalDate
+
+data class KodeverkDto(val betydninger: Map<String, List<BetydningDto>>)
+
+data class BetydningDto(
+    val gyldigFra: LocalDate,
+    val gyldigTil: LocalDate,
+    val beskrivelser: Map<String, BeskrivelseDto>,
+)
+
+data class BeskrivelseDto(
+    val term: String,
+    val tekst: String,
+)
+
+enum class KodeverkSpråk(val kode: String) {
+    BOKMÅL("nb"),
+}
+
+private fun LocalDate.mellom(fra: LocalDate, til: LocalDate) =
+    this.isEqual(fra) || this.isEqual(til) || (this.isAfter(fra) && this.isBefore(til))
+
+/**
+ * @param sisteGjeldende henter siste gjeldende verdi for en gitt kode hvis den mangler for gitt dato
+ */
+fun KodeverkDto.hentGjeldende(
+    kode: String,
+    gjeldendeDato: LocalDate = LocalDate.now(),
+    språk: KodeverkSpråk = KodeverkSpråk.BOKMÅL,
+    sisteGjeldende: Boolean = false,
+): String? {
+    val betydningForKode = betydninger[kode] ?: return null
+    var betydning = betydningForKode.firstOrNull { gjeldendeDato.mellom(it.gyldigFra, it.gyldigTil) }
+    if (betydning == null && sisteGjeldende) {
+        betydning = betydningForKode.maxByOrNull { it.gyldigFra }
+    }
+    return betydning?.beskrivelser?.get(språk.kode)?.term
+}
+
+fun KodeverkDto.mapTerm(): Map<String, String> {
+    return betydninger.mapValues {
+        if (it.value.isEmpty()) {
+            ""
+        } else if (it.value.size != 1) {
+            this.hentGjeldende(it.key) ?: ""
+        } else {
+            it.value.singleOrNull()?.beskrivelser?.get(KodeverkSpråk.BOKMÅL.kode)?.term ?: ""
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/kontrakter/kodeverk/KodeverkTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/kontrakter/kodeverk/KodeverkTest.kt
@@ -1,0 +1,52 @@
+package no.nav.tilleggsstonader.kontrakter.kodeverk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class KodeverkTest {
+    val dato = LocalDate.now()
+
+    @Test
+    internal fun `KodeverkDto mapTerm mapper nykkel til term`() {
+        val betydninger = mapOf(
+            "NOR" to listOf(
+                BetydningDto(
+                    dato,
+                    dato,
+                    mapOf(
+                        "nb" to BeskrivelseDto("NorgeTerm", "NorgeTekst"),
+                    ),
+                ),
+            ),
+            "SWE" to listOf(BetydningDto(dato, dato, mapOf())),
+        )
+        val kodeverkDto = KodeverkDto(betydninger)
+
+        val expected = mapOf(
+            "NOR" to "NorgeTerm",
+            "SWE" to "",
+        )
+        assertThat(kodeverkDto.mapTerm()).isEqualTo(expected)
+    }
+
+    @Test
+    internal fun `KodeverkDto mapTerm henter gjeldende når det finnes historikk`() {
+        val betydninger = mapOf(
+            "NOR" to listOf(
+                BetydningDto(
+                    LocalDate.of(2000, 1, 1),
+                    LocalDate.of(2010, 1, 1),
+                    mapOf("nb" to BeskrivelseDto("IkkeGjeldende", "IkkeGjeldende")),
+                ),
+                BetydningDto(
+                    LocalDate.of(2010, 1, 2),
+                    LocalDate.of(2099, 1, 2),
+                    mapOf("nb" to BeskrivelseDto("Gjeldende", "Gjeldende")),
+                ),
+            ),
+        )
+        val kodeverkDto = KodeverkDto(betydninger)
+        assertThat(kodeverkDto.mapTerm()["NOR"]).isEqualTo("Gjeldende")
+    }
+}


### PR DESCRIPTION
…appe postnummer til poststed

For å kunne fjerne noen todos finnes det behov for å hente inn kodeverk for å blant annet mappe postnummer til poststed