### PR TITLE
Fjerner Vedleggstype eksempel som ikke skal brukes

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/felles/Fagsystem.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/felles/Fagsystem.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.kontrakter.felles
 
-// TODO hva heter fagsystemet?
 enum class Fagsystem(val navn: String) {
     TILLEGGSSTONADER("Tilleggsstønader"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Vedleggstype.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Vedleggstype.kt
@@ -4,8 +4,6 @@ package no.nav.tilleggsstonader.kontrakter.søknad
  * @param tittel brukes som tittel for vedlegget i dokarkiv, sånn at det vises i gosys
  */
 enum class Vedleggstype(val tittel: String) { // TODO språk?
-    EKSEMPEL("Eksempel"), // TODO Denne kan slettes, kun brukt for å sette opp tester
-
     UTGIFTER_PASS_SFO_AKS_BARNEHAGE("Dokumentasjon av utgifter for pass av barn"),
     UTGIFTER_PASS_ANNET("Dokumentasjon av utgifter for pass av barn"),
     EKSTRA_PASS_BEHOV("Dokumentasjon på behov for ekstra pass av barn"),


### PR DESCRIPTION
Fjernet bruk av den i
https://github.com/navikt/tilleggsstonader-soknad-api/pull/89

Fjernet også todo på hva fagsystemet heter, tenker Tilleggsstønader er greit til videre.