### PR TITLE
Oppgaveresponse med versjon

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/oppgave/Oppgave.kt
@@ -7,6 +7,8 @@ import java.time.LocalDate
 
 data class OppgaveResponse(val oppgaveId: Long)
 
+data class OppdatertOppgaveResponse(val oppgaveId: Long, val versjon: Int)
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Oppgave(
@@ -43,7 +45,9 @@ data class Oppgave(
     val prioritet: OppgavePrioritet? = null,
     val status: StatusEnum? = null,
     private var metadata: MutableMap<String, String>? = null,
-)
+) {
+    fun versjonEllerFeil(): Int = versjon ?: error("Mangler versjon på oppgave=$id")
+}
 
 enum class StatusEnum {
     OPPRETTET,

--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/oppgave/Oppgave.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.kontrakter.oppgave
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import java.time.LocalDate
 
 data class OppgaveResponse(val oppgaveId: Long)
 
@@ -32,8 +33,8 @@ data class Oppgave(
     val behandlingstype: String? = null,
     val versjon: Int? = null,
     val mappeId: Long? = null,
-    val fristFerdigstillelse: String? = null,
-    val aktivDato: String? = null,
+    val fristFerdigstillelse: LocalDate? = null,
+    val aktivDato: LocalDate? = null,
     val opprettetTidspunkt: String? = null,
     val opprettetAv: String? = null,
     val endretAv: String? = null,


### PR DESCRIPTION
* Oppdatert datoer til LocalDate (de sendes på likt format som tidligere, så skal ikke være noe breaking)
* Lagt til ny type for å kunne returnere versjon ved patchning av oppgave. 
  * Hadde kunnet vurdert å returnere oppgaven som returneres fra oppgaveappen, men det vil være en breaking change/ny versjon pga `OppgaveResponse` som inneholder `oppgaveId` og ikke `id`