### PR TITLE
Metoden skal splitte opp i utbetalingsmåneder, og må då få en periode…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/felles/Periode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/kontrakter/felles/Periode.kt
@@ -149,10 +149,13 @@ fun <P : Periode<LocalDate>, VAL> P.splitPerLøpendeMåneder(medNyPeriode: (fom:
  */
 fun LocalDate.sisteDagenILøpendeMåned(): LocalDate {
     val nesteMåned = this.plusMonths(1)
-    return if (this.dayOfMonth >= nesteMåned.lengthOfMonth()) {
-        nesteMåned.tilSisteDagIMåneden()
-    } else {
+    val nyttDatoErSisteDagINesteMåned by lazy {
+        this.month != nesteMåned.month && nesteMåned.dayOfMonth == nesteMåned.lengthOfMonth()
+    }
+    return if (this.dayOfMonth < nesteMåned.lengthOfMonth() || nyttDatoErSisteDagINesteMåned) {
         nesteMåned.minusDays(1)
+    } else {
+        nesteMåned.tilSisteDagIMåneden()
     }
 }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/kontrakter/felles/DatoUtilDatoINesteMånedTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/kontrakter/felles/DatoUtilDatoINesteMånedTest.kt
@@ -23,9 +23,11 @@ class DatoUtilDatoINesteMånedTest {
 
     @Test
     fun `hvis dagens måned har flere dager enn neste skal man bruke siste dagen i måneden`() {
-        assertThat(LocalDate.of(2025, 1, 29).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 28))
-        assertThat(LocalDate.of(2025, 1, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 28))
-        assertThat(LocalDate.of(2025, 1, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 28))
+        assertThat(LocalDate.of(2025, 1, 29).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 27))
+        assertThat(LocalDate.of(2025, 1, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 27))
+        assertThat(LocalDate.of(2025, 1, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 27))
+
+        assertThat(LocalDate.of(2025, 3, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 4, 29))
     }
 
     @Nested
@@ -45,9 +47,9 @@ class DatoUtilDatoINesteMånedTest {
 
         @Test
         fun `hvis dagens måned har flere dager enn neste skal man bruke siste dagen i måneden`() {
-            assertThat(LocalDate.of(2024, 1, 29).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 29))
-            assertThat(LocalDate.of(2024, 1, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 29))
-            assertThat(LocalDate.of(2024, 1, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 29))
+            assertThat(LocalDate.of(2024, 1, 29).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 28))
+            assertThat(LocalDate.of(2024, 1, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 28))
+            assertThat(LocalDate.of(2024, 1, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 28))
         }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/kontrakter/felles/PeriodeSplitPerLøpendeMånederTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/kontrakter/felles/PeriodeSplitPerLøpendeMånederTest.kt
@@ -61,14 +61,29 @@ class PeriodeSplitPerLøpendeMånederTest {
             )
     }
 
+    // 29 dager i februar i 2024
     @Test
     fun `fra sluttet på måneden`() {
         val datoperiode = Datoperiode(SISTE_JAN_2024, SISTE_APRIL_2024)
         assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> datoperiode.copy(fom = fom, tom = tom) })
             .containsExactly(
-                Datoperiode(SISTE_JAN_2024, SISTE_FEB_2024),
-                Datoperiode(FØRSTE_MARS_2024, SISTE_MARS_2024),
-                Datoperiode(FØRSTE_APRIL_2024, SISTE_APRIL_2024),
+                Datoperiode(SISTE_JAN_2024, SISTE_FEB_2024.minusDays(1)),
+                Datoperiode(SISTE_FEB_2024, LocalDate.of(2024, 3, 28)),
+                Datoperiode(LocalDate.of(2024, 3, 29), LocalDate.of(2024, 4, 28)),
+                Datoperiode(LocalDate.of(2024, 4, 29), SISTE_APRIL_2024),
+            )
+    }
+
+    // 28 dager i februar i 2025
+    // må inkludere en dag for februar også for å utbetale et beløp som gjelder for februar og
+    @Test
+    fun `siste dagen i januar skal ikke spise opp februar`() {
+        val datoperiode = Datoperiode(LocalDate.of(2025, 1, 28), LocalDate.of(2025, 3, 31))
+        assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> datoperiode.copy(fom = fom, tom = tom) })
+            .containsExactly(
+                Datoperiode(LocalDate.of(2025, 1, 28), LocalDate.of(2025, 2, 27)),
+                Datoperiode(LocalDate.of(2025, 2, 28), LocalDate.of(2025, 3, 27)),
+                Datoperiode(LocalDate.of(2025, 3, 28), LocalDate.of(2025, 3, 31)),
             )
     }
 


### PR DESCRIPTION
… som begynner i neste måned for at den måneden også skal få en utbetaling, hvis ikke får man ikke utbetalt for februar når man innvilger fra siste januar

Fortsetting på https://github.com/navikt/tilleggsstonader-kontrakter/pull/98

Er usikker på om denne er riktig. 
Den tidligere løsningen "spiste opp den neste måneden" hvis den måneden hadde færre antall dager.
Eks hvis vi har en periode som slutter 31 mars til 31 mai, så får en periode som er 31 mars til 30 april, og en periode fra første mai til siste mai. Man får då ikke utbetalt noe for april. Men det er kanskje riktig? 