### PR TITLE
Legger til dagpenger som en TypeYtelsePeriode

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/ytelse/YtelsePerioderDto.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/ytelse/YtelsePerioderDto.kt
@@ -52,6 +52,7 @@ data class YtelsePeriode(
 
 enum class TypeYtelsePeriode {
     AAP,
+    DAGPENGER,
     ENSLIG_FORSØRGER,
     OMSTILLINGSSTØNAD,
 }


### PR DESCRIPTION
Legger til `DAGPENGER` for å kunne inkludere responsen fra `DP-datadeling perioder` til ts-sak.

Her burde jeg kanskje også utvide `YtelsePeriode` med
```
DagpengerYtelseType =  DAGPENGER_ARBEIDSSOKER_ORDINAER || DAGPENGER_PERMITTERING_ORDINAER || DAGPENGER_PERMITTERING_FISKEINDUSTRI
```
som kommer fra dagpenger?