### PR TITLE
👔 Fjern en-til-en mapping mellom stønadstype og brevkode da det ikke er en en-til-en relasjon for daglig reise

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/sak/DokumentBrevkode.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/sak/DokumentBrevkode.kt
@@ -1,16 +1,12 @@
 package no.nav.tilleggsstonader.kontrakter.sak
 
-import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-
 enum class DokumentBrevkode(
     val verdi: String,
-    val stønadstype: Stønadstype,
 ) {
-    BARNETILSYN("NAV 11-12.15", Stønadstype.BARNETILSYN),
-    LÆREMIDLER("NAV 11-12.16", Stønadstype.LÆREMIDLER),
-    BOUTGIFTER("NAV 11-12.19", Stønadstype.BOUTGIFTER),
-    DAGLIG_REISE_TSO("NAV 11-12.21", Stønadstype.DAGLIG_REISE_TSO),
-    DAGLIG_REISE_TSR("NAV 11-12.21", Stønadstype.DAGLIG_REISE_TSR),
+    BARNETILSYN("NAV 11-12.15"),
+    LÆREMIDLER("NAV 11-12.16"),
+    BOUTGIFTER("NAV 11-12.19"),
+    DAGLIG_REISE("NAV 11-12.21"),
     ;
 
     companion object {


### PR DESCRIPTION
Henger sammen med: https://github.com/navikt/tilleggsstonader-sak/pull/843