### PR TITLE
Legger til kjøreliste-skjema og koder knyttet til dokumenttype og vedleggstype

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/dokarkiv/Dokumenttype.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/dokarkiv/Dokumenttype.kt
@@ -34,6 +34,8 @@ enum class Dokumenttype {
     DAGLIG_REISE_TSO_INTERNT_VEDTAK,
     DAGLIG_REISE_TSO_KLAGE_VEDTAKSBREV,
     DAGLIG_REISE_TSO_KLAGE_INTERNT_VEDTAK,
+    DAGLIG_REISE_TSO_KJØRELISTE,
+    DAGLIG_REISE_TSO_KJØRELISTE_VEDLEGG,
 
     // DAGLIG_REISE_TSR_SØKNAD,
     // DAGLIG_REISE_TSR_SØKNAD_VEDLEGG,
@@ -42,6 +44,8 @@ enum class Dokumenttype {
     DAGLIG_REISE_TSR_INTERNT_VEDTAK,
     DAGLIG_REISE_TSR_KLAGE_VEDTAKSBREV,
     DAGLIG_REISE_TSR_KLAGE_INTERNT_VEDTAK,
+    DAGLIG_REISE_TSR_KJØRELISTE,
+    DAGLIG_REISE_TSR_KJØRELISTE_VEDLEGG,
 }
 
 data class Dokumentyper(
@@ -52,6 +56,8 @@ data class Dokumentyper(
     val interntVedtak: Dokumenttype,
     val klageVedtaksbrev: Dokumenttype,
     val klageInterntVedtak: Dokumenttype,
+    val kjøreliste: Dokumenttype?,
+    val kjørelisteVedlegg: Dokumenttype?,
 )
 
 val Stønadstype.dokumenttyper: Dokumentyper
@@ -66,6 +72,8 @@ val Stønadstype.dokumenttyper: Dokumentyper
                     interntVedtak = Dokumenttype.BARNETILSYN_INTERNT_VEDTAK,
                     klageVedtaksbrev = Dokumenttype.BARNETILSYN_KLAGE_VEDTAKSBREV,
                     klageInterntVedtak = Dokumenttype.BARNETILSYN_KLAGE_INTERNT_VEDTAK,
+                    kjøreliste = null,
+                    kjørelisteVedlegg = null,
                 )
             Stønadstype.LÆREMIDLER ->
                 Dokumentyper(
@@ -76,6 +84,8 @@ val Stønadstype.dokumenttyper: Dokumentyper
                     interntVedtak = Dokumenttype.LÆREMIDLER_INTERNT_VEDTAK,
                     klageVedtaksbrev = Dokumenttype.LÆREMIDLER_KLAGE_VEDTAKSBREV,
                     klageInterntVedtak = Dokumenttype.LÆREMIDLER_KLAGE_INTERNT_VEDTAK,
+                    kjøreliste = null,
+                    kjørelisteVedlegg = null,
                 )
             Stønadstype.BOUTGIFTER ->
                 Dokumentyper(
@@ -86,6 +96,8 @@ val Stønadstype.dokumenttyper: Dokumentyper
                     interntVedtak = Dokumenttype.BOUTGIFTER_INTERNT_VEDTAK,
                     klageVedtaksbrev = Dokumenttype.BOUTGIFTER_KLAGE_VEDTAKSBREV,
                     klageInterntVedtak = Dokumenttype.BOUTGIFTER_KLAGE_INTERNT_VEDTAK,
+                    kjøreliste = null,
+                    kjørelisteVedlegg = null,
                 )
             Stønadstype.DAGLIG_REISE_TSO ->
                 Dokumentyper(
@@ -96,6 +108,8 @@ val Stønadstype.dokumenttyper: Dokumentyper
                     interntVedtak = Dokumenttype.DAGLIG_REISE_TSO_INTERNT_VEDTAK,
                     klageVedtaksbrev = Dokumenttype.DAGLIG_REISE_TSO_KLAGE_VEDTAKSBREV,
                     klageInterntVedtak = Dokumenttype.DAGLIG_REISE_TSO_KLAGE_INTERNT_VEDTAK,
+                    kjøreliste = Dokumenttype.DAGLIG_REISE_TSO_KJØRELISTE,
+                    kjørelisteVedlegg = Dokumenttype.DAGLIG_REISE_TSO_KJØRELISTE_VEDLEGG,
                 )
             Stønadstype.DAGLIG_REISE_TSR ->
                 Dokumentyper(
@@ -106,5 +120,7 @@ val Stønadstype.dokumenttyper: Dokumentyper
                     interntVedtak = Dokumenttype.DAGLIG_REISE_TSR_INTERNT_VEDTAK,
                     klageVedtaksbrev = Dokumenttype.DAGLIG_REISE_TSR_KLAGE_VEDTAKSBREV,
                     klageInterntVedtak = Dokumenttype.DAGLIG_REISE_TSR_KLAGE_INTERNT_VEDTAK,
+                    kjøreliste = Dokumenttype.DAGLIG_REISE_TSR_KJØRELISTE,
+                    kjørelisteVedlegg = Dokumenttype.DAGLIG_REISE_TSR_KJØRELISTE_VEDLEGG,
                 )
         }

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/FeltTyper.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/FeltTyper.kt
@@ -9,6 +9,11 @@ data class TekstFelt(
     val verdi: String,
 )
 
+data class NumeriskFelt(
+    val label: String,
+    val verdi: Int,
+)
+
 data class EnumFelt<T>(
     val label: String,
     val verdi: T,

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/KjørelisteSkjema.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/KjørelisteSkjema.kt
@@ -1,0 +1,16 @@
+package no.nav.tilleggsstonader.kontrakter.søknad
+
+data class KjørelisteSkjema(
+    val reisedagerPerUkeAvsnitt: List<UkeMedReisedager>,
+    override val dokumentasjon: List<DokumentasjonFelt>,
+) : Skjema
+
+data class UkeMedReisedager(
+    val ukeLabel: String,
+    val reisedager: List<Reisedag>,
+)
+
+data class Reisedag(
+    val dato: DatoFelt,
+    val parkeringsutgift: NumeriskFelt? = null,
+)

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Vedleggstype.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Vedleggstype.kt
@@ -18,4 +18,6 @@ enum class Vedleggstype(
     // Læremidler
     DOKUMENTASJON_FUNKSJONSNEDSETTELSE("Dokumentasjon på funksjonsnedsettelse"),
     UTGIFTER_LÆREMIDLER("Dokumentasjon på utgifter til læremidler"),
+
+    PARKERINGSUTGIFT("Dokumentasjon på parkeringsutgift"),
 }


### PR DESCRIPTION
Knyttet til å sende inn kjørelister.

Legger til:
- Dokumenttype for kjøreliste og kjøreliste-vedlegg
- KjørelisteSkjema - selve kjørelisten som blir produsert og skal leses av ts-sak
- Ny vedleggstype for parkeringutgifter