### PR TITLE
Rename søknad til skjema

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/InnsendtSkjema.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/InnsendtSkjema.kt
@@ -3,7 +3,7 @@ package no.nav.tilleggsstonader.kontrakter.søknad
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
 import java.time.LocalDateTime
 
-data class Søknadsskjema<T : Skjemadata>(
+data class InnsendtSkjema<T : Skjemadata>(
     val ident: String,
     val mottattTidspunkt: LocalDateTime,
     val språk: Språkkode,

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/KjørelisteSkjema.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/KjørelisteSkjema.kt
@@ -3,7 +3,7 @@ package no.nav.tilleggsstonader.kontrakter.søknad
 data class KjørelisteSkjema(
     val reisedagerPerUkeAvsnitt: List<UkeMedReisedager>,
     override val dokumentasjon: List<DokumentasjonFelt>,
-) : Skjema
+) : Skjemadata
 
 data class UkeMedReisedager(
     val ukeLabel: String,

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Søknadsskjema.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Søknadsskjema.kt
@@ -3,13 +3,13 @@ package no.nav.tilleggsstonader.kontrakter.søknad
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
 import java.time.LocalDateTime
 
-data class Søknadsskjema<T : Skjema>(
+data class Søknadsskjema<T : Skjemadata>(
     val ident: String,
     val mottattTidspunkt: LocalDateTime,
     val språk: Språkkode,
     val skjema: T,
 )
 
-sealed interface Skjema {
+sealed interface Skjemadata {
     val dokumentasjon: List<DokumentasjonFelt>
 }

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBarnetilsyn.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBarnetilsyn.kt
@@ -9,4 +9,4 @@ data class SøknadsskjemaBarnetilsyn(
     val aktivitet: AktivitetAvsnitt,
     val barn: BarnAvsnitt,
     override val dokumentasjon: List<DokumentasjonFelt>,
-) : Skjema
+) : Skjemadata

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBoutgifterFyllUtSendInn.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBoutgifterFyllUtSendInn.kt
@@ -4,10 +4,10 @@ import no.nav.tilleggsstonader.kontrakter.søknad.boutgifter.fyllutsendinn.Boutg
 
 /**
  * Søknadskjema som sendes inn fra FyllUt/SendInn
- * @param dokumentasjon fylles ikke i, men er påkrevd av [Skjema]
+ * @param dokumentasjon fylles ikke i, men er påkrevd av [Skjemadata]
  */
 data class SøknadsskjemaBoutgifterFyllUtSendInn(
     val language: String,
     val data: BoutgifterFyllUtSendInnData,
     override val dokumentasjon: List<DokumentasjonFelt> = emptyList(),
-) : Skjema
+) : Skjemadata

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaDagligReiseFyllUtSendInn.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaDagligReiseFyllUtSendInn.kt
@@ -4,10 +4,10 @@ import no.nav.tilleggsstonader.kontrakter.søknad.dagligreise.fyllutsendinn.Dagl
 
 /**
  * Søknadskjema som sendes inn fra FyllUt/SendInn
- * @param dokumentasjon fylles ikke i, men er påkrevd av [Skjema]
+ * @param dokumentasjon fylles ikke i, men er påkrevd av [Skjemadata]
  */
 data class SøknadsskjemaDagligReiseFyllUtSendInn(
     val language: String,
     val data: DagligReiseFyllUtSendInnData,
     override val dokumentasjon: List<DokumentasjonFelt> = emptyList(),
-) : Skjema
+) : Skjemadata

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaLæremidler.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaLæremidler.kt
@@ -7,4 +7,4 @@ data class SøknadsskjemaLæremidler(
     val hovedytelse: HovedytelseAvsnitt,
     val utdanning: UtdanningAvsnitt,
     override val dokumentasjon: List<DokumentasjonFelt>,
-) : Skjema
+) : Skjemadata


### PR DESCRIPTION
Renamer `Søknadsskjema` -> `InnsendtSkjema` og `Skjema` -> `Skjemadata`

Bakgrunnen er at tilleggsstonader-soknad-api går litt vekk fra søknad-begrepet, og bruker heller "skjema".