### PR TITLE
Håndter nytt felt "attachments" i fyll-ut søknader

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Rammevedtak.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/Rammevedtak.kt
@@ -9,7 +9,7 @@ data class RammevedtakDto(
     val aktivitetsadresse: String,
     val aktivitetsnavn: String,
     val uker: List<RammevedtakUkeDto>,
-    val helligdager: List<HelligdagDto>
+    val helligdager: List<HelligdagDto>,
 )
 
 data class RammevedtakUkeDto(

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/boutgifter/fyllutsendinn/BoutgifterFyllUtSendInnData.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/boutgifter/fyllutsendinn/BoutgifterFyllUtSendInnData.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
  * Feltene i [SkjemaBoutgifter] kan genereres automatisk fra [FyllUtSendInnSkjemaParser] i test
  * Felter som ikke er definierte vil feile, for å unngå at man ikke plukker opp nye felter hvis det blir lagt till i søknadsdialogen.
  */
-@JsonIgnoreProperties("metadata", "state", "_vnote", ignoreUnknown = false)
+@JsonIgnoreProperties("metadata", "state", "_vnote", "attachments", ignoreUnknown = false)
 data class BoutgifterFyllUtSendInnData(
     val data: SkjemaBoutgifter,
 )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/dagligreise/fyllutsendinn/DagligReiseFyllUtSendInnData.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/dagligreise/fyllutsendinn/DagligReiseFyllUtSendInnData.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
  * Feltene i [SkjemaDagligReise] kan genereres automatisk fra [FyllUtSendInnSkjemaParser] i test
  * Felter som ikke er definierte vil feile, for å unngå at man ikke plukker opp nye felter hvis det blir lagt till i søknadsdialogen.
  */
-@JsonIgnoreProperties("state", "_vnote", "selfDeclaration", ignoreUnknown = false)
+@JsonIgnoreProperties("state", "_vnote", "selfDeclaration", "attachments", ignoreUnknown = false)
 data class DagligReiseFyllUtSendInnData(
     val data: SkjemaDagligReise,
     val metadata: MetadataDagligReise,


### PR DESCRIPTION
Legger til ignorering av nytt felt som kommer i fyll-ut søknad, "attachments". Vedlegg er uansett inkludert i journalposten så vi skal ikke trenge noe mer informasjon