### PR TITLE
Juster reiseavstand folkereg adresse

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/reisetilsamling/AvsnittReiseTilSamling.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/reisetilsamling/AvsnittReiseTilSamling.kt
@@ -28,8 +28,8 @@ data class AdresseAvsnitt(
 )
 
 data class ReiseavstandAvsnitt(
-    val reiseFraFolkeregistrertAdr: EnumFelt<JaNei>,
-    val adresseDetSkalReisesFra: AdresseAvsnitt,
+    val skalReiseFraFolkeregistrertAdresse: EnumFelt<JaNei>,
+    val adresseDetSkalReisesFra: AdresseAvsnitt?,
     val antallKilometerEnVei: VerdiFelt<String>?,
     val aktivitetsadresse: AdresseAvsnitt,
 )


### PR DESCRIPTION
Endrer navngivnign og gjør adresseDetSkalReisesFra nullable. Navngivning stemmer overens med andre steder og bruker "skal" som andre bools, nullable ettersom denne kun er satt dersom man reiser fra noe annet enn folkereg adresse.