### PR TITLE
gjør om manglende avsnitt til avsnitt

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/ArbeidOgOppholdAvsnitt.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/ArbeidOgOppholdAvsnitt.kt
@@ -1,12 +1,14 @@
 package no.nav.tilleggsstonader.kontrakter.søknad.felles
 
+import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
+import no.nav.tilleggsstonader.kontrakter.søknad.Avsnitt
 import no.nav.tilleggsstonader.kontrakter.søknad.DatoFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFlereValgFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.JaNei
 import no.nav.tilleggsstonader.kontrakter.søknad.SelectFelt
 
-data class ArbeidOgOpphold(
+data class ArbeidOgOppholdAvsnitt(
     val jobberIAnnetLand: EnumFelt<JaNei>?,
     val jobbAnnetLand: SelectFelt<String>?,
     val harPengestøtteAnnetLand: EnumFlereValgFelt<TypePengestøtte>?,
@@ -15,7 +17,12 @@ data class ArbeidOgOpphold(
     val oppholdUtenforNorgeSiste12mnd: List<OppholdUtenforNorge>,
     val harOppholdUtenforNorgeNeste12mnd: EnumFelt<JaNei>?,
     val oppholdUtenforNorgeNeste12mnd: List<OppholdUtenforNorge>,
-)
+) : Avsnitt {
+    override fun getSpråkMapper(): Map<Språkkode, String> =
+        mapOf(
+            Språkkode.NB to "Arbeid og opphold",
+        )
+}
 
 data class OppholdUtenforNorge(
     val land: SelectFelt<String>,

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/HovedytelseAvsnitt.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/HovedytelseAvsnitt.kt
@@ -7,7 +7,7 @@ import no.nav.tilleggsstonader.kontrakter.søknad.EnumFlereValgFelt
 
 data class HovedytelseAvsnitt(
     val hovedytelse: EnumFlereValgFelt<Hovedytelse>,
-    val arbeidOgOpphold: ArbeidOgOpphold?,
+    val arbeidOgOpphold: ArbeidOgOppholdAvsnitt?,
 ) : Avsnitt {
     override fun getSpråkMapper(): Map<Språkkode, String> =
         mapOf(

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/læremidler/AvsnittLæremidler.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/læremidler/AvsnittLæremidler.kt
@@ -1,10 +1,10 @@
 package no.nav.tilleggsstonader.kontrakter.søknad.læremidler
 
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
+import no.nav.tilleggsstonader.kontrakter.søknad.Avsnitt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFlereValgFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.JaNei
-import no.nav.tilleggsstonader.kontrakter.søknad.SpråkMappable
 
 data class UtdanningAvsnitt(
     val aktiviteter: EnumFlereValgFelt<String>? = null,
@@ -17,7 +17,7 @@ data class UtdanningAvsnitt(
     val harTidligereFullførtVgs: EnumFelt<JaNei>? = null,
     val harRettTilUtstyrsstipend: HarRettTilUtstyrsstipend? = null,
     val harFunksjonsnedsettelse: EnumFelt<JaNei>,
-) : SpråkMappable {
+) : Avsnitt {
     override fun getSpråkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Utdanning",


### PR DESCRIPTION
utdanningavsnitt ble glemt, skulle vært Avsnitt og ikke språkmappable. arbeidogopphold brukes som avsnitt i søknad-api, men var ikke navngitt slik. legger det til for å gjøre det tydeligere og legger på avsnitt interfacet der og.