### PR TITLE
fiks de/serialisering feil av språkmapper

### DIFF
--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/KjørelisteSkjema.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/KjørelisteSkjema.kt
@@ -7,7 +7,7 @@ data class KjørelisteSkjema(
     val reisedagerPerUkeAvsnitt: List<UkeMedReisedager>,
     override val dokumentasjon: List<DokumentasjonFelt>,
 ) : Skjemadata {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Søknad om støtte til pass av barn",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SpråkMappable.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SpråkMappable.kt
@@ -3,5 +3,5 @@ package no.nav.tilleggsstonader.kontrakter.søknad
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
 
 interface SpråkMappable {
-    fun getSpråkMapper(): Map<Språkkode, String>
+    fun språkMapper(): Map<Språkkode, String>
 }

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBarnetilsyn.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBarnetilsyn.kt
@@ -11,7 +11,7 @@ data class SøknadsskjemaBarnetilsyn(
     val barn: BarnAvsnitt,
     override val dokumentasjon: List<DokumentasjonFelt>,
 ) : Skjemadata {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Søknad om støtte til pass av barn",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBoutgifterFyllUtSendInn.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaBoutgifterFyllUtSendInn.kt
@@ -13,7 +13,7 @@ data class SøknadsskjemaBoutgifterFyllUtSendInn(
     override val dokumentasjon: List<DokumentasjonFelt> = emptyList(),
     val formRevision: Int?,
 ) : Skjemadata {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Søknad om støtte til boutgifter",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaDagligReiseFyllUtSendInn.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaDagligReiseFyllUtSendInn.kt
@@ -13,7 +13,7 @@ data class SøknadsskjemaDagligReiseFyllUtSendInn(
     override val dokumentasjon: List<DokumentasjonFelt> = emptyList(),
     val formRevision: Int?,
 ) : Skjemadata {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Søknad om støtte til daglig reise",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaLæremidler.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaLæremidler.kt
@@ -9,7 +9,7 @@ data class SøknadsskjemaLæremidler(
     val utdanning: UtdanningAvsnitt,
     override val dokumentasjon: List<DokumentasjonFelt>,
 ) : Skjemadata {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Søknad om støtte læremidler",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaReiseTilSamling.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/SøknadsskjemaReiseTilSamling.kt
@@ -15,7 +15,7 @@ data class SøknadsskjemaReiseTilSamling(
     val reisemåte: ReisemåteAvsnitt,
     override val dokumentasjon: List<DokumentasjonFelt>,
 ) : Skjemadata {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Søknad om støtte til reise til samling",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/barnetilsyn/AvsnittBarnetilsyn.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/barnetilsyn/AvsnittBarnetilsyn.kt
@@ -13,7 +13,7 @@ data class AktivitetAvsnitt(
     val annenAktivitet: EnumFelt<AnnenAktivitetType>?,
     val lønnetAktivitet: EnumFelt<JaNei>?,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Aktivitet",
         )
@@ -29,7 +29,7 @@ enum class AnnenAktivitetType {
 data class BarnAvsnitt(
     val barnMedBarnepass: List<BarnMedBarnepass>,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Barn",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/ArbeidOgOppholdAvsnitt.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/ArbeidOgOppholdAvsnitt.kt
@@ -18,7 +18,7 @@ data class ArbeidOgOppholdAvsnitt(
     val harOppholdUtenforNorgeNeste12mnd: EnumFelt<JaNei>?,
     val oppholdUtenforNorgeNeste12mnd: List<OppholdUtenforNorge>,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Arbeid og opphold",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/HovedytelseAvsnitt.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/felles/HovedytelseAvsnitt.kt
@@ -9,7 +9,7 @@ data class HovedytelseAvsnitt(
     val hovedytelse: EnumFlereValgFelt<Hovedytelse>,
     val arbeidOgOpphold: ArbeidOgOppholdAvsnitt?,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Hovedytelse",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/læremidler/AvsnittLæremidler.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/læremidler/AvsnittLæremidler.kt
@@ -18,7 +18,7 @@ data class UtdanningAvsnitt(
     val harRettTilUtstyrsstipend: HarRettTilUtstyrsstipend? = null,
     val harFunksjonsnedsettelse: EnumFelt<JaNei>,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Utdanning",
         )

--- a/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/reisetilsamling/AvsnittReiseTilSamling.kt
+++ b/kontrakter-felles/main/kotlin/no/nav/tilleggsstonader/kontrakter/søknad/reisetilsamling/AvsnittReiseTilSamling.kt
@@ -16,7 +16,7 @@ data class TilleggsopplysningerAnnenAktivitetAvsnitt(
     val erUnder25År: EnumFelt<JaNei>?,
     val måBetaleForReiseTilSkole: EnumFelt<JaNei>?,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Tillegssopplysninger om annen aktivitet",
         )
@@ -35,7 +35,7 @@ data class AktivitetAvsnitt(
     val tilleggsopplysningerAnnenAktivitet: TilleggsopplysningerAnnenAktivitetAvsnitt?,
     val annenAktivitetTypeUtdanning: EnumFelt<AktivitetTypeUtdanning>?,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Aktivitet",
         )
@@ -61,7 +61,7 @@ data class AvreiseadresseAvsnitt(
     val skalReiseFraFolkeregistrertAdresse: EnumFelt<JaNei>,
     val adresseDetSkalReisesFra: Adresse?,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Avreiseadresse",
         )
@@ -98,7 +98,7 @@ data class ReisemåteAvsnitt(
     val harTTKort: EnumFelt<JaNei>?,
     val reiseMedBilUtgifter: ReiseMedBilUtgifterAvsnitt?,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Reisemåte",
         )
@@ -118,7 +118,7 @@ data class ReiseMedBilUtgifterAvsnitt(
     val ferge: VerdiFelt<String>?,
     val piggdekkavgift: VerdiFelt<String>?,
 ) : Avsnitt {
-    override fun getSpråkMapper(): Map<Språkkode, String> =
+    override fun språkMapper(): Map<Språkkode, String> =
         mapOf(
             Språkkode.NB to "Utgifter for reise med bil",
         )


### PR DESCRIPTION
dette er en irriterende greie som gjør at Jackson forventer at språkmapper skal være satt som property siden den er prefikset med `get`. hvis man forsøker å lese fra en JSON og deserialisere til en klasse som implementerer språkMapper, så vil det feile siden det typisk ikke er en del av dataen. enkleste løsning er å bare unngå å kalle den noe med `get`.